### PR TITLE
Add LinkStorage installer.

### DIFF
--- a/src/Installation/LinkStorage.php
+++ b/src/Installation/LinkStorage.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Laravel\SparkInstaller\Installation;
+
+use Laravel\SparkInstaller\NewCommand;
+use Symfony\Component\Process\Process;
+
+class LinkStorage
+{
+    protected $command;
+
+    /**
+     * Create a new installation helper instance.
+     *
+     * @param  NewCommand  $command
+     * @return void
+     */
+    public function __construct(NewCommand $command) {
+        $this->command = $command;
+    }
+
+    /**
+     * Run the installation helper.
+     *
+     * @return void
+     */
+    public function install() {
+        if (! $this->command->output->confirm('Would you like to link your Storage Path?', true)) {
+            return;
+        }
+
+        $this->command->output->writeln('<info>Linking Storage...</info>');
+
+        if (windows_os()) {
+            $commandline = 'mklink /J "'.$this->command->path.'/public/storage" "'.$this->command->path.'/storage/app/public"';
+        } else {
+            $commandline = 'ln -nfs "'.$this->command->path.'/storage/app/public" "'.$this->command->path.'/public/storage"';
+        }
+
+        $process = (new Process($commandline, $this->command->path))->setTimeout(null);
+
+        if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
+            $process->setTty(true);
+        }
+
+        $process->run(function ($type, $line) {
+            $this->command->output->write($line);
+        });
+    }
+}

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -73,6 +73,7 @@ class NewCommand extends SymfonyCommand
             Installation\AddAppProviderToConfiguration::class,
             Installation\RunNpmInstall::class,
             Installation\RunGulp::class,
+            Installation\LinkStorage::class,
         ];
 
         foreach ($installers as $installer) {


### PR DESCRIPTION
This fixes the [Added LinkStorage workflow](https://github.com/laravel/spark-installer/pull/4) pull request on Windows.

Tested on [Windows 10](http://i.imgur.com/EyoieP9.png) and [Ubuntu](http://i.imgur.com/auYuVm5.png).

It could be done with the [symlink](http://php.net/manual/en/function.symlink.php) function but on Windows you have to run the Console as Administrator.
