### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
         }
     },
     "require": {
-        "illuminate/support": "~5.1",
+        "illuminate/support": "~5.1|~5.2",
         "symfony/console": "~2.7|~3.0",
         "symfony/process": "~2.7|~3.0",
-        "illuminate/filesystem": "~5.1",
+        "illuminate/filesystem": "~5.1|~5.2",
         "guzzlehttp/guzzle": "~6.0"
     },
     "bin": [


### PR DESCRIPTION
When installing laravel/valet and laravel/spark-installer via composer the dependencies will fail.  

`Problem 1
    - illuminate/filesystem v5.2.25 requires illuminate/contracts 5.3.* -> satisfiable by illuminate/contracts[5.3.x-dev] but these conflict with your requirements or minimum-stability.
    - Conclusion: don't install laravel/spark-installer v1.0.3
    - Conclusion: don't install laravel/spark-installer v1.0.2
    - Conclusion: remove illuminate/contracts v5.2.37
    - Conclusion: don't install illuminate/contracts v5.2.37
    - illuminate/filesystem v5.1.1 requires illuminate/contracts 5.1.* -> satisfiable by illuminate/contracts[v5.1.1, v5.1.13, v5.1.16, v5.1.20, v5.1.22, v5.1.25, v5.1.28, v5.1.30, v5.1.31, v5.1.8].
    - illuminate/filesystem v5.1.13 requires illuminate/contracts 5.1.* -> satisfiable by illuminate/contracts[v5.1.1, v5.1.13, v5.1.16, v5.1.20, v5.1.22, v5.1.25, v5.1.28, v5.1.30, v5.1.31, v5.1.8].
    - illuminate/filesystem v5.1.16 requires illuminate/contracts 5.1.* -> satisfiable by illuminate/contracts[v5.1.1, v5.1.13, v5.1.16, v5.1.20, v5.1.22, v5.1.25, v5.1.28, v5.1.30, v5.1.31, v5.1.8].
    - illuminate/filesystem v5.1.2 requires illuminate/contracts 5.1.* -> satisfiable by illuminate/contracts[v5.1.1, v5.1.13, v5.1.16, v5.1.20, v5.1.22, v5.1.25, v5.1.28, v5.1.30, v5.1.31, v5.1.8].
    - illuminate/filesystem v5.1.20 requires illuminate/contracts 5.1.* -> satisfiable by illuminate/contracts[v5.1.1, v5.1.13, v5.1.16, v5.1.20, v5.1.22, v5.1.25, v5.1.28, v5.1.30, v5.1.31, v5.1.8].
    - illuminate/filesystem v5.1.22 requires illuminate/contracts 5.1.* -> satisfiable by illuminate/contracts[v5.1.1, v5.1.13, v5.1.16, v5.1.20, v5.1.22, v5.1.25, v5.1.28, v5.1.30, v5.1.31, v5.1.8].
    - illuminate/filesystem v5.1.25 requires illuminate/contracts 5.1.* -> satisfiable by illuminate/contracts[v5.1.1, v5.1.13, v5.1.16, v5.1.20, v5.1.22, v5.1.25, v5.1.28, v5.1.30, v5.1.31, v5.1.8].
    - illuminate/filesystem v5.1.28 requires illuminate/contracts 5.1.* -> satisfiable by illuminate/contracts[v5.1.1, v5.1.13, v5.1.16, v5.1.20, v5.1.22, v5.1.25, v5.1.28, v5.1.30, v5.1.31, v5.1.8].
    - illuminate/filesystem v5.1.30 requires illuminate/contracts 5.1.* -> satisfiable by illuminate/contracts[v5.1.1, v5.1.13, v5.1.16, v5.1.20, v5.1.22, v5.1.25, v5.1.28, v5.1.30, v5.1.31, v5.1.8].
    - illuminate/filesystem v5.1.31 requires illuminate/contracts 5.1.* -> satisfiable by illuminate/contracts[v5.1.1, v5.1.13, v5.1.16, v5.1.20, v5.1.22, v5.1.25, v5.1.28, v5.1.30, v5.1.31, v5.1.8].
    - illuminate/filesystem v5.1.6 requires illuminate/contracts 5.1.* -> satisfiable by illuminate/contracts[v5.1.1, v5.1.13, v5.1.16, v5.1.20, v5.1.22, v5.1.25, v5.1.28, v5.1.30, v5.1.31, v5.1.8].
    - illuminate/filesystem v5.1.8 requires illuminate/contracts 5.1.* -> satisfiable by illuminate/contracts[v5.1.1, v5.1.13, v5.1.16, v5.1.20, v5.1.22, v5.1.25, v5.1.28, v5.1.30, v5.1.31, v5.1.8].
    - Can only install one of: illuminate/contracts[v5.1.1, v5.2.37].
    - Can only install one of: illuminate/contracts[v5.1.13, v5.2.37].
    - Can only install one of: illuminate/contracts[v5.1.16, v5.2.37].
    - Can only install one of: illuminate/contracts[v5.1.20, v5.2.37].
    - Can only install one of: illuminate/contracts[v5.1.22, v5.2.37].
    - Can only install one of: illuminate/contracts[v5.1.25, v5.2.37].
    - Can only install one of: illuminate/contracts[v5.1.28, v5.2.37].
    - Can only install one of: illuminate/contracts[v5.1.30, v5.2.37].
    - Can only install one of: illuminate/contracts[v5.1.31, v5.2.37].
    - Can only install one of: illuminate/contracts[v5.1.8, v5.2.37].
    - Conclusion: don't install symfony/finder v3.1.2|install illuminate/filesystem v5.1.1|install illuminate/filesystem v5.1.13|install illuminate/filesystem v5.1.16|install illuminate/filesystem v5.1.2|install illuminate/filesystem v5.1.20|install illuminate/filesystem v5.1.22|install illuminate/filesystem v5.1.25|install illuminate/filesystem v5.1.28|install illuminate/filesystem v5.1.30|install illuminate/filesystem v5.1.31|install illuminate/filesystem v5.1.6|install illuminate/filesystem v5.1.8
    - Installation request for illuminate/contracts (locked at v5.2.37) -> satisfiable by illuminate/contracts[v5.2.37].
    - Installation request for laravel/spark-installer ^1.0 -> satisfiable by laravel/spark-installer[v1.0.0, v1.0.2, v1.0.3].
    - Conclusion: remove symfony/finder v3.1.2|install illuminate/filesystem v5.1.1|install illuminate/filesystem v5.1.13|install illuminate/filesystem v5.1.16|install illuminate/filesystem v5.1.2|install illuminate/filesystem v5.1.20|install illuminate/filesystem v5.1.22|install illuminate/filesystem v5.1.25|install illuminate/filesystem v5.1.28|install illuminate/filesystem v5.1.30|install illuminate/filesystem v5.1.31|install illuminate/filesystem v5.1.6|install illuminate/filesystem v5.1.8
    - laravel/spark-installer v1.0.0 requires illuminate/filesystem ~5.1 -> satisfiable by illuminate/filesystem[v5.1.1, v5.1.13, v5.1.16, v5.1.2, v5.1.20, v5.1.22, v5.1.25, v5.1.28, v5.1.30, v5.1.31, v5.1.6, v5.1.8, v5.2.0, v5.2.19, v5.2.21, v5.2.24, v5.2.25, v5.2.26, v5.2.27, v5.2.28, v5.2.31, v5.2.32, v5.2.37, v5.2.6, v5.2.7].
    - illuminate/filesystem v5.2.0 requires symfony/finder 2.8.*|3.0.* -> satisfiable by symfony/finder[v2.8.0, v2.8.1, v2.8.2, v2.8.3, v2.8.4, v2.8.5, v2.8.6, v2.8.7, v2.8.8, v3.0.0, v3.0.1, v3.0.2, v3.0.3, v3.0.4, v3.0.5, v3.0.6, v3.0.7, v3.0.8].
    - illuminate/filesystem v5.2.19 requires symfony/finder 2.8.*|3.0.* -> satisfiable by symfony/finder[v2.8.0, v2.8.1, v2.8.2, v2.8.3, v2.8.4, v2.8.5, v2.8.6, v2.8.7, v2.8.8, v3.0.0, v3.0.1, v3.0.2, v3.0.3, v3.0.4, v3.0.5, v3.0.6, v3.0.7, v3.0.8].
    - illuminate/filesystem v5.2.21 requires symfony/finder 2.8.*|3.0.* -> satisfiable by symfony/finder[v2.8.0, v2.8.1, v2.8.2, v2.8.3, v2.8.4, v2.8.5, v2.8.6, v2.8.7, v2.8.8, v3.0.0, v3.0.1, v3.0.2, v3.0.3, v3.0.4, v3.0.5, v3.0.6, v3.0.7, v3.0.8].
    - illuminate/filesystem v5.2.24 requires symfony/finder 2.8.*|3.0.* -> satisfiable by symfony/finder[v2.8.0, v2.8.1, v2.8.2, v2.8.3, v2.8.4, v2.8.5, v2.8.6, v2.8.7, v2.8.8, v3.0.0, v3.0.1, v3.0.2, v3.0.3, v3.0.4, v3.0.5, v3.0.6, v3.0.7, v3.0.8].
    - illuminate/filesystem v5.2.26 requires symfony/finder 2.8.*|3.0.* -> satisfiable by symfony/finder[v2.8.0, v2.8.1, v2.8.2, v2.8.3, v2.8.4, v2.8.5, v2.8.6, v2.8.7, v2.8.8, v3.0.0, v3.0.1, v3.0.2, v3.0.3, v3.0.4, v3.0.5, v3.0.6, v3.0.7, v3.0.8].
    - illuminate/filesystem v5.2.27 requires symfony/finder 2.8.*|3.0.* -> satisfiable by symfony/finder[v2.8.0, v2.8.1, v2.8.2, v2.8.3, v2.8.4, v2.8.5, v2.8.6, v2.8.7, v2.8.8, v3.0.0, v3.0.1, v3.0.2, v3.0.3, v3.0.4, v3.0.5, v3.0.6, v3.0.7, v3.0.8].
    - illuminate/filesystem v5.2.28 requires symfony/finder 2.8.*|3.0.* -> satisfiable by symfony/finder[v2.8.0, v2.8.1, v2.8.2, v2.8.3, v2.8.4, v2.8.5, v2.8.6, v2.8.7, v2.8.8, v3.0.0, v3.0.1, v3.0.2, v3.0.3, v3.0.4, v3.0.5, v3.0.6, v3.0.7, v3.0.8].
    - illuminate/filesystem v5.2.31 requires symfony/finder 2.8.*|3.0.* -> satisfiable by symfony/finder[v2.8.0, v2.8.1, v2.8.2, v2.8.3, v2.8.4, v2.8.5, v2.8.6, v2.8.7, v2.8.8, v3.0.0, v3.0.1, v3.0.2, v3.0.3, v3.0.4, v3.0.5, v3.0.6, v3.0.7, v3.0.8].
    - illuminate/filesystem v5.2.32 requires symfony/finder 2.8.*|3.0.* -> satisfiable by symfony/finder[v2.8.0, v2.8.1, v2.8.2, v2.8.3, v2.8.4, v2.8.5, v2.8.6, v2.8.7, v2.8.8, v3.0.0, v3.0.1, v3.0.2, v3.0.3, v3.0.4, v3.0.5, v3.0.6, v3.0.7, v3.0.8].
    - illuminate/filesystem v5.2.37 requires symfony/finder 2.8.*|3.0.* -> satisfiable by symfony/finder[v2.8.0, v2.8.1, v2.8.2, v2.8.3, v2.8.4, v2.8.5, v2.8.6, v2.8.7, v2.8.8, v3.0.0, v3.0.1, v3.0.2, v3.0.3, v3.0.4, v3.0.5, v3.0.6, v3.0.7, v3.0.8].
    - illuminate/filesystem v5.2.6 requires symfony/finder 2.8.*|3.0.* -> satisfiable by symfony/finder[v2.8.0, v2.8.1, v2.8.2, v2.8.3, v2.8.4, v2.8.5, v2.8.6, v2.8.7, v2.8.8, v3.0.0, v3.0.1, v3.0.2, v3.0.3, v3.0.4, v3.0.5, v3.0.6, v3.0.7, v3.0.8].
    - illuminate/filesystem v5.2.7 requires symfony/finder 2.8.*|3.0.* -> satisfiable by symfony/finder[v2.8.0, v2.8.1, v2.8.2, v2.8.3, v2.8.4, v2.8.5, v2.8.6, v2.8.7, v2.8.8, v3.0.0, v3.0.1, v3.0.2, v3.0.3, v3.0.4, v3.0.5, v3.0.6, v3.0.7, v3.0.8].
    - Can only install one of: symfony/finder[v2.8.0, v3.1.2].
    - Can only install one of: symfony/finder[v2.8.1, v3.1.2].
    - Can only install one of: symfony/finder[v2.8.2, v3.1.2].
    - Can only install one of: symfony/finder[v2.8.3, v3.1.2].
    - Can only install one of: symfony/finder[v2.8.4, v3.1.2].
    - Can only install one of: symfony/finder[v2.8.5, v3.1.2].
    - Can only install one of: symfony/finder[v2.8.6, v3.1.2].
    - Can only install one of: symfony/finder[v2.8.7, v3.1.2].
    - Can only install one of: symfony/finder[v2.8.8, v3.1.2].
    - Can only install one of: symfony/finder[v3.0.0, v3.1.2].
    - Can only install one of: symfony/finder[v3.0.1, v3.1.2].
    - Can only install one of: symfony/finder[v3.0.2, v3.1.2].
    - Can only install one of: symfony/finder[v3.0.3, v3.1.2].
    - Can only install one of: symfony/finder[v3.0.4, v3.1.2].
    - Can only install one of: symfony/finder[v3.0.5, v3.1.2].
    - Can only install one of: symfony/finder[v3.0.6, v3.1.2].
    - Can only install one of: symfony/finder[v3.0.7, v3.1.2].
    - Can only install one of: symfony/finder[v3.0.8, v3.1.2].
    - Installation request for symfony/finder (locked at v3.1.2) -> satisfiable by symfony/finder[v3.1.2].`
