### PR TITLE
Windows shell executable command

### DIFF
--- a/spark.cmd
+++ b/spark.cmd
@@ -1,0 +1,2 @@
+@echo off
+php  "%~dp0\spark" %*


### PR DESCRIPTION
I created a Windows shell executable command, for running 'spark' from command line.
Simply put the spark-installer in %PATH% variable and that's it.
Now it work like a Linux/Unix environment.