### PR TITLE
Specify version of spark to install

### DIFF
--- a/src/Installation/DownloadSpark.php
+++ b/src/Installation/DownloadSpark.php
@@ -69,7 +69,8 @@ class DownloadSpark
      */
     protected function zipResponse()
     {
-        $release = $this->latestSparkRelease();
+        $release = $this->command->input->getArgument('use')
+            ?? $release = $this->latestSparkRelease();
 
         try {
             return (string) (new HttpClient)->get(

--- a/src/Installation/DownloadSpark.php
+++ b/src/Installation/DownloadSpark.php
@@ -69,7 +69,7 @@ class DownloadSpark
      */
     protected function zipResponse()
     {
-        $release = $this->command->input->getArgument('use')
+        $release = $this->command->input->getOption('use')
             ?? $release = $this->latestSparkRelease();
 
         try {

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -43,6 +43,7 @@ class NewCommand extends SymfonyCommand
             ->setName('new')
             ->setDescription('Create a new Spark application')
             ->addArgument('name', InputArgument::REQUIRED, 'The name of the application')
+            ->addArgument('use', InputArgument::OPTIONAL, 'Specify the spark version to install')
             ->addOption('braintree', null, InputOption::VALUE_NONE, 'Install Braintree versions of the file stubs')
             ->addOption('team-billing', null, InputOption::VALUE_NONE, 'Configure Spark for team based billing');
     }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -43,7 +43,7 @@ class NewCommand extends SymfonyCommand
             ->setName('new')
             ->setDescription('Create a new Spark application')
             ->addArgument('name', InputArgument::REQUIRED, 'The name of the application')
-            ->addArgument('use', InputArgument::OPTIONAL, 'Specify the spark version to install')
+            ->addOption('use', null, InputOption::VALUE_OPTIONAL, 'Specify the spark version to install')
             ->addOption('braintree', null, InputOption::VALUE_NONE, 'Install Braintree versions of the file stubs')
             ->addOption('team-billing', null, InputOption::VALUE_NONE, 'Configure Spark for team based billing');
     }


### PR DESCRIPTION
Unable to specify version of spark when running `spark new`, so I get error because have not upgraded to 6.  The only problem with this pr is that the version resource is not found.  

I.e.  
The current version is URL is 
    https://spark.laravel.com/api/releases/6.0.3/download?api_token=...
and the expected endpoint
   https://spark.laravel.com/api/releases/5.0.3/download?api_token=....
returns 404. 

Is there an api endpoint available for other versions?  I tried using the resource ID (v5.0.3 => 68), but to no avail. 

Only worth merging this if I can find out what the correct endpoint is. 
