### PR TITLE
Add spark.bat so installer works on Windows

### DIFF
--- a/spark.bat
+++ b/spark.bat
@@ -1,0 +1,4 @@
+@ECHO OFF
+setlocal DISABLEDELAYEDEXPANSION
+SET BIN_TARGET=%~dp0/spark
+php "%BIN_TARGET%" %*


### PR DESCRIPTION
.bat file for running the installer on Windows. Tested on Windows 10