### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+composer.lock


### PR DESCRIPTION
do not commit the composer lock file.

when forking and updating the repo, users run `composer update` to get the latest dependencies. this creates a `composer.lock` file that we don't want committed back to the package repo.

similar to other Laravel packages that don't commit the lock file.

https://github.com/laravel/lumen-installer/blob/master/.gitignore
https://github.com/laravel/horizon/blob/2.0/.gitignore
https://github.com/laravel/tinker/blob/master/.gitignore