### PR TITLE
Force Spark to install the ~9.0

### DIFF
--- a/src/Installation/UpdateComposerFile.php
+++ b/src/Installation/UpdateComposerFile.php
@@ -61,7 +61,7 @@ class UpdateComposerFile
      */
     protected function addSparkDependency($composer)
     {
-        $composer['require']['laravel/spark-aurelius'] = '*@dev';
+        $composer['require']['laravel/spark-aurelius'] = '~9.0';
 
         return $composer;
     }


### PR DESCRIPTION
At the moment Spark is installing the @dev version, which actually refers to the Spark version ~6.0.
The change force Spark to install version ~9.0 as the Upgrade Guide suggest to do (https://spark.laravel.com/docs/9.0/upgrade)