### PR TITLE
Improve Exception Handling and Code Style

### DIFF
--- a/src/InteractsWithSparkConfiguration.php
+++ b/src/InteractsWithSparkConfiguration.php
@@ -66,10 +66,12 @@ trait InteractsWithSparkConfiguration
     {
         if (! empty($_SERVER['HOME'])) {
             return $_SERVER['HOME'];
-        } elseif (! empty($_SERVER['HOMEDRIVE']) && ! empty($_SERVER['HOMEPATH'])) {
-            return $_SERVER['HOMEDRIVE'].$_SERVER['HOMEPATH'];
-        } else {
-            throw new Exception('Cannot determine home directory.');
         }
+        
+        if (! empty($_SERVER['HOMEDRIVE']) && ! empty($_SERVER['HOMEPATH'])) {
+            return $_SERVER['HOMEDRIVE'].$_SERVER['HOMEPATH'];
+        }
+        
+        throw new Exception('Cannot determine home directory.');
     }
 }

--- a/src/RegisterCommand.php
+++ b/src/RegisterCommand.php
@@ -36,7 +36,7 @@ class RegisterCommand extends SymfonyCommand
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        if (! $this->valid($input->getArgument('token'))) {
+        if (! $this->valid($input->getArgument('token'), $output)) {
             return $this->tokenIsInvalid($output);
         }
 
@@ -55,9 +55,10 @@ class RegisterCommand extends SymfonyCommand
      * Determine if the given token is valid.
      *
      * @param  string  $token
+     * @param  OutputInterface|null  $output
      * @return bool
      */
-    protected function valid($token)
+    protected function valid($token, $output = null)
     {
         try {
             (new HttpClient)->get(
@@ -67,7 +68,9 @@ class RegisterCommand extends SymfonyCommand
 
             return true;
         } catch (Exception $e) {
-            var_dump($e->getMessage());
+            if ($output) {
+                $output->writeln('<error>Error: ' . $e->getMessage() . '</error>');
+            }
 
             return false;
         }


### PR DESCRIPTION
## Improve Exception Handling and Code Style

### Changes

#### 1. Enhanced Exception Handling in `RegisterCommand.php`
- Replaced `var_dump($e->getMessage())` with proper console error output
- Added optional `OutputInterface` parameter to `valid()` method for better error reporting
- Exception messages are now displayed using `$output->writeln('<error>...')` for proper formatting
- Maintains backward compatibility with optional output parameter
- Improved PHPDoc with parameter documentation

**Before:**
```php
} catch (Exception $e) {
    var_dump($e->getMessage());
    return false;
}
```

**After:**
```php
} catch (Exception $e) {
    if ($output) {
        $output->writeln('<error>Error: ' . $e->getMessage() . '</error>');
    }
    return false;
}
```

#### 2. Refactored `homePath()` Method in `InteractsWithSparkConfiguration.php`
- Removed `elseif/else` chain in favor of early returns
- Improved code readability with flatter structure
- Each condition is now independent and easier to understand
- Exception is thrown directly at the end instead of in an `else` block

**Before:**
```php
if (! empty($_SERVER['HOME'])) {
    return $_SERVER['HOME'];
} elseif (! empty($_SERVER['HOMEDRIVE']) && ! empty($_SERVER['HOMEPATH'])) {
    return $_SERVER['HOMEDRIVE'].$_SERVER['HOMEPATH'];
} else {
    throw new Exception('Cannot determine home directory.');
}
```

**After:**
```php
if (! empty($_SERVER['HOME'])) {
    return $_SERVER['HOME'];
}

if (! empty($_SERVER['HOMEDRIVE']) && ! empty($_SERVER['HOMEPATH'])) {
    return $_SERVER['HOMEDRIVE'].$_SERVER['HOMEPATH'];
}

throw new Exception('Cannot determine home directory.');
```

### Benefits
- ✅ Better user experience with properly formatted error messages
- ✅ Removed debug code (`var_dump`) from production code
- ✅ Improved code maintainability and readability
- ✅ Follows Symfony Console best practices
- ✅ Cleaner control flow with early returns

### Testing
- No functional changes to existing logic
- Error messages are now properly displayed in the console
- All existing functionality preserved